### PR TITLE
Support multiple static directories

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -16,3 +16,4 @@ Patches and Suggestions
 - Jakub Zalewski
 - NeuronQ
 - Dominic Rodger
+- Eduardo Rivas (jerivas)

--- a/docs/user/advanced.rst
+++ b/docs/user/advanced.rst
@@ -36,8 +36,9 @@ To change behavior, pass the appropriate keyword arguments to
 * To change which files are considered templates, subclass the
   ``Renderer`` object and override ``is_template``.
 * To change where static files (such as CSS or JavaScript) are stored,
-  set ``staticpath="mystaticfiles"`` (the default is ``None``, which
-  means no files are considered to be static files).
+  set ``staticpath=["mystaticfiles"]`` (the default is ``None``, which
+  means no files are considered to be static files). You can pass
+  multiple directories in the list: ``staticpath=["foo", "bar"]``.
 
 Finally, just save the script as ``build.py`` (or something similar)
 and run it with your Python interpreter.

--- a/docs/user/quickstart.rst
+++ b/docs/user/quickstart.rst
@@ -48,11 +48,13 @@ Configuration
   ``./templates``);
 * ``--outpath`` - the directory to place rendered files in (defaults
   to ``.``);
-* ``--static`` - the directory within ``srcpath`` where static files
-  (such as CSS and JavaScript) are stored. Static files are copied to
-  the output directory without any template compilation, maintaining
-  any directory structure. This defaults to ``None``, meaning no files
-  are considered to be static files.
+* ``--static`` - the directory (or directories) within ``srcpath``
+  where static files   (such as CSS and JavaScript) are stored. Static
+  files are copied to the output directory without any template
+  compilation, maintaining any directory structure. This defaults to
+  ``None``, meaning no files are considered to be static files. You
+  can pass multiple directories separating them by commas: 
+  ``staticpath="foo,bar/baz,lorem"``.
 
 More advanced configuration can be done using the staticjinja API, see
 :ref:`custom-build-scripts` for details.

--- a/staticjinja/cli.py
+++ b/staticjinja/cli.py
@@ -4,8 +4,8 @@
 """staticjinja
 
 Usage:
-  staticjinja build [--srcpath=<srcpath> --outpath=<outpath> --static=<static>]
-  staticjinja watch [--srcpath=<srcpath> --outpath=<outpath> --static=<static>]
+  staticjinja build [--srcpath=<srcpath> --outpath=<outpath> --static=<a,b,c>]
+  staticjinja watch [--srcpath=<srcpath> --outpath=<outpath> --static=<a,b,c>]
   staticjinja (-h | --help)
   staticjinja --version
 
@@ -44,21 +44,21 @@ def main():
               % outpath)
         sys.exit(1)
 
-    staticdir = arguments['--static']
-    staticpath = None
+    staticdirs = arguments['--static']
+    staticpaths = None
 
-    if staticdir:
-        staticpath = os.path.join(srcpath, staticdir)
-
-    if staticpath and not os.path.isdir(staticpath):
-        print("The static files directory '%s' is invalid."
-              % staticpath)
-        sys.exit(1)
+    if staticdirs:
+        staticpaths = staticdirs.split(",")
+        for path in staticpaths:
+            path = os.path.join(srcpath, path)
+            if not os.path.isdir(path):
+                print("The static files directory '%s' is invalid." % path)
+                sys.exit(1)
 
     renderer = staticjinja.make_renderer(
         searchpath=srcpath,
         outpath=outpath,
-        staticpath=staticdir
+        staticpaths=staticpaths
     )
 
     use_reloader = arguments['watch']

--- a/staticjinja/staticjinja.py
+++ b/staticjinja/staticjinja.py
@@ -45,8 +45,8 @@ class Renderer(object):
     :param logger:
         A logging.Logger object used to log events.
 
-    :param staticpath:
-        The name of the directory to get static files from (relative to
+    :param staticpaths:
+        List of directory names to get static files from (relative to
         searchpath).
     """
 
@@ -58,7 +58,7 @@ class Renderer(object):
                  logger,
                  contexts=None,
                  rules=None,
-                 staticpath=None
+                 staticpaths=None
                  ):
         self._env = environment
         self.searchpath = searchpath
@@ -67,7 +67,7 @@ class Renderer(object):
         self.logger = logger
         self.contexts = contexts or []
         self.rules = rules or []
-        self.staticpath = staticpath
+        self.staticpaths = staticpaths
 
     @property
     def template_names(self):
@@ -140,17 +140,20 @@ class Renderer(object):
         """Check if a file is a static file (which should be copied, rather
         than compiled using Jinja2).
 
-        A file is considered static if it lives in the directory
-        specified in ``staticpath``.
+        A file is considered static if it lives in any of the directories
+        specified in ``staticpaths``.
 
         :param filename: the name of the file to check
 
         """
-        if self.staticpath is None:
+        if self.staticpaths is None:
             # We're not using static file support
             return False
 
-        return filename.startswith(self.staticpath + os.path.sep)
+        for path in self.staticpaths:
+            if filename.startswith(path + os.path.sep):
+                return True
+        return False
 
     def is_partial(self, filename):
         """Check if a file is a partial.
@@ -351,7 +354,7 @@ def make_renderer(searchpath="templates",
                   rules=None,
                   encoding="utf8",
                   extensions=None,
-                  staticpath=None):
+                  staticpaths=None):
     """Create a :class:`Renderer <Renderer>` object.
 
     :param searchpath:
@@ -384,9 +387,9 @@ def make_renderer(searchpath="templates",
         A list of :ref:`Jinja extensions <jinja-extensions>` that the
         :class:`jinja2.Environment` should use. Defaults to ``[]``.
 
-    :param staticpath:
-        A string representing the name of the directory to get static files
-        from (relative to searchpath). Defaults to ``None``.
+    :param staticpaths:
+        List of directories to get static files from (relative to searchpath).
+        Defaults to ``None``.
 
     """
     # Coerce search to an absolute path if it is not already
@@ -411,5 +414,5 @@ def make_renderer(searchpath="templates",
                     logger=logger,
                     rules=rules,
                     contexts=contexts,
-                    staticpath=staticpath,
+                    staticpaths=staticpaths,
                     )

--- a/test_staticjinja.py
+++ b/test_staticjinja.py
@@ -25,8 +25,11 @@ def renderer(template_path, build_path):
     template_path.join('template1.html').write('Test 1')
     template_path.join('template2.html').write('Test 2')
     template_path.mkdir('sub').join('template3.html').write('Test {{b}}')
-    template_path.mkdir('fakestatic').join('hello.css').write(
+    template_path.mkdir('static_css').join('hello.css').write(
         'a { color: blue; }'
+    )
+    template_path.mkdir('static_js').join('hello.js').write(
+        'var a = function () {return true};'
     )
     contexts = [('template2.html', lambda t: {'a': 1}),
                 ('.*template3.html', lambda: {'b': 3}), ]
@@ -43,7 +46,7 @@ def reloader(renderer):
 
 
 def test_template_names(renderer):
-    renderer.staticpath = "fakestatic"
+    renderer.staticpaths = ["static_css", "static_js"]
     expected_templates = set(['template1.html',
                               'template2.html',
                               'sub/template3.html'])
@@ -151,8 +154,8 @@ def test_event_handler_static(reloader, template_path):
     def fake_copy_static(files):
         found_files.extend(files)
 
-    reloader.renderer.staticpath = "fakestatic"
+    reloader.renderer.staticpaths = ["static_css"]
     reloader.renderer.copy_static = fake_copy_static
-    template1_path = str(template_path.join("fakestatic").join("hello.css"))
+    template1_path = str(template_path.join("static_css").join("hello.css"))
     reloader.event_handler("modified", template1_path)
     assert found_files == list(reloader.renderer.static_names)


### PR DESCRIPTION
This PR adds support for multiple static directories, they can be passed as a string of comma-separated names to the CLI and as a list to the Renderer. I tested it with a single directory (backwards compatible) and multiple directories and it works great. If any of the folders doesn't exist, it throws the same error as the current version.

I've also updated the docs to reflect the changes ~~(though I didn't build them, so that part is untested).~~ All tests pass in Python 2.7 and 3.4.