### PR TITLE
srcpath did not work

### DIFF
--- a/staticjinja/cli.py
+++ b/staticjinja/cli.py
@@ -26,6 +26,7 @@ def main():
 
     if arguments['--srcpath'] is not None:
         srcpath = arguments['--srcpath']
+        srcpath = os.path.join(os.getcwd(), srcpath)
     else:
         srcpath = os.path.join(os.getcwd(), 'templates')
 


### PR DESCRIPTION
Hi, I started using staticjinja today with python3 and I realized that using --scrpath="templates" (Just in case, I know that this is the default) created no output in my output directory. Using this code, it works for me.