### PR TITLE
Allow parent directories to be marked partial or ignored

### DIFF
--- a/staticjinja/staticjinja.py
+++ b/staticjinja/staticjinja.py
@@ -164,23 +164,27 @@ class Site(object):
         Partial files are not rendered, but they are used in rendering
         templates.
 
-        A file is considered ignored if it is prefixed with an ``'_'``.
+        A file is considered ignored if it or any of its parent directories
+        are prefixed with an ``'_'``.
 
         :param filename: the name of the file to check
 
         """
-        return os.path.basename(filename).startswith('_')
+
+        return any((x.startswith("_") for x in filename.split(os.path.sep)))
 
     def is_ignored(self, filename):
         """Check if a file is an ignored file.
 
         Ignored files are neither rendered nor used in rendering templates.
 
-        A file is considered ignored if it is prefixed with an ``'.'``.
+        A file is considered ignored if it or any of its parent directories
+        are prefixed with an ``'.'``.
 
         :param filename: the name of the file to check
         """
-        return os.path.basename(filename).startswith('.')
+
+        return any((x.startswith(".") for x in filename.split(os.path.sep)))
 
     def is_template(self, filename):
         """Check if a file is a template.


### PR DESCRIPTION
This pull requests allow for whole directories within `sourcepath` to be marked as partial or ignored. I'm using this to mark as 'partial' a directory that I want ignored, but has a whole lot of content that I don't want to rename (nor do I want to 'hide' the directory with a leading '.')

This keeps the current behavior of checking against the filename, but also extends it to support any leading component containing a '.' or '_'. 

Tests don't pass here, but that doesn't seem to be my fault (particularly the flake8 bits - they fail because of line 31 in reloader.py, which I've not touched - though it'd be trivial to fix)