### PR TITLE
fixed typo in docu

### DIFF
--- a/docs/user/quickstart.rst
+++ b/docs/user/quickstart.rst
@@ -54,7 +54,7 @@ Configuration
   compilation, maintaining any directory structure. This defaults to
   ``None``, meaning no files are considered to be static files. You
   can pass multiple directories separating them by commas:
-  ``staticpath="foo,bar/baz,lorem"``.
+  ``--static="foo,bar/baz,lorem"``.
 
 More advanced configuration can be done using the staticjinja API, see
 :ref:`custom-build-scripts` for details.


### PR DESCRIPTION
for the staticjinja build --static".." the example was wrong:

changed it from `staticpath="foo,bar/baz,lorem"` to --static="foo,bar/baz,lorem"