### PR TITLE
Allow passing keyword arguments to the jinja2 Environment

### DIFF
--- a/staticjinja/staticjinja.py
+++ b/staticjinja/staticjinja.py
@@ -316,7 +316,8 @@ def make_site(searchpath="templates",
               encoding="utf8",
               extensions=None,
               staticpaths=None,
-              filters=None):
+              filters=None,
+              env_kwargs={}):
     """Create a :class:`Site <Site>` object.
 
     :param searchpath:
@@ -362,6 +363,10 @@ def make_site(searchpath="templates",
         A dictionary of Jinja2 filters to add to the Environment.
         Defaults to ``{}``.
 
+    :param env_kwargs:
+        A dictionary that will be passed as keyword arguments to the
+        jinja2 Environment. Defaults to ``{}``.
+
     """
     # Coerce search to an absolute path if it is not already
     if not os.path.isabs(searchpath):
@@ -374,7 +379,11 @@ def make_site(searchpath="templates",
 
     loader = FileSystemLoader(searchpath=searchpath,
                               encoding=encoding)
-    environment = Environment(loader=loader, extensions=extensions or [])
+    env_kwargs.pop("loader", None)
+    env_kwargs.pop("extensions", None)
+    env_kwargs.pop("filters", None)
+    environment = Environment(loader=loader, extensions=extensions or [],
+                              **env_kwargs)
     if filters:
         for k, v in filters.items():
             environment.filters[k] = v


### PR DESCRIPTION
I was working on a project and needed to tweak the jinja2 Environment settings to better control whitespace output in my templates. This change allows passing a custom dictionary as kwargs when [constructing the Environment](http://jinja.pocoo.org/docs/dev/api/#jinja2.Environment). Since you're already using the `filters`, `extensions`, and `loader` kwargs, I just pop them from the dict before passing them to the Environment, so this should be 100% backwards compatible and completely optional.

Example usage:
```python
site = make_site(
    outpath="dist",
    env_kwargs={"trim_blocks": True, "lstrip_blocks": True}  # Extra kwargs passed to the Environment
)
```