### PR TITLE
Use copy2 instead of copyfile to copy metadata for static resources.

### DIFF
--- a/staticjinja/staticjinja.py
+++ b/staticjinja/staticjinja.py
@@ -266,7 +266,7 @@ class Site(object):
             output_location = os.path.join(self.outpath, f)
             print("Copying %s to %s." % (f, output_location))
             self._ensure_dir(f)
-            shutil.copyfile(input_location, output_location)
+            shutil.copy2(input_location, output_location)
 
     def get_dependencies(self, filename):
         """Get a list of files that depends on the file named *filename*.


### PR DESCRIPTION
Currently, static resources will always have a modified time of when the build script was run. It is often a good idea that modified time is preserved for static files that aren't actually modified.

https://docs.python.org/3/library/shutil.html#shutil.copy2