### PR TITLE
Handle created events in reloader as well. Editors like PyCharm save …

### DIFF
--- a/staticjinja/reloader.py
+++ b/staticjinja/reloader.py
@@ -26,7 +26,7 @@ class Reloader(object):
 
         :param filename: the path to the file that triggered the event.
         """
-        return (event_type == "modified" and
+        return (event_type in ("modified", "created") and
                 filename.startswith(self.searchpath) and
                 os.path.isfile(filename))
 

--- a/test_staticjinja.py
+++ b/test_staticjinja.py
@@ -140,7 +140,8 @@ def test_should_handle(reloader, template_path):
     test4_path.write('')
     assert reloader.should_handle("modified", str(template1_path))
     assert reloader.should_handle("modified", str(test4_path))
-    assert not reloader.should_handle("created", str(template1_path))
+    assert reloader.should_handle("created", str(template1_path))
+    assert not reloader.should_handle("deleted", str(template1_path))
 
 
 def test_event_handler(reloader, template_path):


### PR DESCRIPTION
…by first deleting then creating, it seems, so the modified event is never triggered. It seems reasonable to automatically render newly added files anyways.