### PR TITLE
Improvements to the context workflow

### DIFF
--- a/test_staticjinja.py
+++ b/test_staticjinja.py
@@ -29,6 +29,7 @@ def site(template_path, build_path):
     template_path.join('template1.html').write('Test 1')
     template_path.join('template2.html').write('Test 2')
     template_path.mkdir('sub').join('template3.html').write('Test {{b}}')
+    template_path.join('template4.html').write('Test {{b}} and {{c}}')
     template_path.mkdir('static_css').join('hello.css').write(
         'a { color: blue; }'
     )
@@ -37,7 +38,9 @@ def site(template_path, build_path):
     )
     template_path.join('favicon.ico').write('Fake favicon')
     contexts = [('template2.html', lambda t: {'a': 1}),
-                ('.*template3.html', lambda: {'b': 3}), ]
+                ('.*template3.html', lambda: {'b': 3}),
+                ('template4.html', {'b': 4, 'c': 5}),
+                ('.*[4-9].html', {'c': 6})]
     rules = [('template2.html', lambda env, t, a: None), ]
     return make_site(searchpath=str(template_path),
                      outpath=str(build_path),
@@ -54,7 +57,8 @@ def test_template_names(site):
     site.staticpaths = ["static_css", "static_js", "favicon.ico"]
     expected_templates = set(['template1.html',
                               'template2.html',
-                              'sub/template3.html'])
+                              'sub/template3.html',
+                              'template4.html'])
     assert set(site.template_names) == expected_templates
 
 
@@ -71,6 +75,13 @@ def test_get_context(site):
     assert site.get_context(
         site.get_template("sub/template3.html")
     ) == {'b': 3}
+    assert site.get_context(
+        site.get_template("template4.html")
+    ) == {'b': 4, 'c': 5}
+    site.mergecontexts = True
+    assert site.get_context(
+        site.get_template("template4.html")
+    ) == {'b': 4, 'c': 6}
 
 
 def test_get_rule(site):


### PR DESCRIPTION
I propose two minor improvements to the contexts workflow. They are fully tox-ed, documented and backward compatible. Note in particular that applying commit 6a260a0 changes the main package without changing test_staticjinja.py and without breaking any test (the next commit does modify tests to cover the new workflow).

First, as examplified by the knights example in the documentation, the current workflow is unnecessarily complicated when the context is really simple. I added the possibility to directly pass a dictionary instead of a function returning a dictionary. I also added to the documentation an example where the context generator uses the template (this possibility was somewhat hidden in the documentation). Here backward compatibility of the interface is obvious. On the implementation level I removed the separation betwen _get_context_generator and get_context. My understanding is that it prevented some accidental exception catching but I think my code also does that since I don't have any try block here. Also I think the way the context_generator was tested to accept a parameter was a bit unfortunate since, as far as I can see, the try block could catch an error coming from the execution of context_generator and not only its call. This could make debugging difficult for users (more generally the code is full of these kind of try/except). As far as I understand, testing whether a function accepts a parameter changed a bit in python3.3 so I added a helper function _has_argument which uses a bit of inspection.

Next, and more importantly, I added the possibility to have several regex matching a given template. Indeed I had examples where I wanted a common element for all templates like the base url of the web site (which I don't want to hardcode since it changes from the dev server to production server) and some context specific to a given template. Here backward compatibility is ensured by defaulting to the original behavior. The new parameter (both for  `Site.__init__` and for `make_site`) is called mergecontexts.

Thanks for your work on staticjinja.