### PR TITLE
Smart reload

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 *.py[co]
 
 # Packages
-*.egg
+*.egg*
 *.egg-info
 dist
 build
@@ -16,8 +16,13 @@ develop-eggs
 # Installer logs
 pip-log.txt
 
-# Unit test / coverage reports
+# Vim temp files
+.*.sw*
+
+# Unit test / coverage reports / py.test cache
 .coverage
+htmlcov/
+.cache
 .tox
 
 #Translations
@@ -28,5 +33,6 @@ pip-log.txt
 
 # Compiled html
 /*.html
+/example/posts/
 
 docs/_build

--- a/staticjinja/__init__.py
+++ b/staticjinja/__init__.py
@@ -5,3 +5,4 @@ from __future__ import absolute_import
 
 from .reloader import Reloader
 from .staticjinja import make_site, Site
+from .dep_graph import DepGraph

--- a/staticjinja/dep_graph.py
+++ b/staticjinja/dep_graph.py
@@ -1,0 +1,80 @@
+# -*- coding:utf-8 -*-
+
+"""
+Dependency graph for staticjina
+"""
+
+from copy import deepcopy
+
+
+class DepGraph(object):
+    """
+    A directed graph which will handle dependencies between templates and data
+    files in a site.
+
+    :param site:
+        A :class:`Site <Site>` object.
+
+    """
+    def __init__(self, site):
+        self.parents = dict(
+                (s, set()) for s in site.jinja_names + site.data_names
+                )
+        self.children = deepcopy(self.parents)
+
+        for filename in site.jinja_names:
+            self.parents[filename] = site.get_file_dep(filename)
+            for d in self.parents[filename]:
+                self.children[d].add(filename)
+
+        self.site = site
+
+    def connected_components(self, adjacency, start):
+        """Returns the (directed) connected component of start in the graph with
+        given adjacency dict.
+
+        Uses a classical depth first search.
+
+        :param adjacency: the adjacency dict to be used (will be either
+        self.children or self.parents in all foreseen uses)
+
+        :param start: the vertex in the graph whose connected component we
+        seek.
+        """
+
+        seen = set([start])
+        stack = [iter(adjacency[start])]
+        while stack:
+            children = stack[-1]
+            try:
+                child = next(children)
+                if child not in seen:
+                    yield child
+                seen.add(child)
+                stack.append(iter(adjacency[child]))
+            except StopIteration:
+                stack.pop()
+
+    def get_descendants(self, filename):
+        """Returns all descendant of the given template or data file.
+
+        :param filename: the template or data file whose descendant we seek.
+        """
+        return self.connected_components(self.children, filename)
+
+    def update(self, filename):
+        """
+        Updates the part of this dependency graph directly linked to some
+        template or data file.
+
+        :param filename: A string giving the relative path of the template or
+        data file.
+        """
+        old_parents = self.parents.get(filename, set())
+        new_parents = self.site.get_file_dep(filename)
+        if new_parents != old_parents:
+            for lost_parent in old_parents.difference(new_parents):
+                self.children[lost_parent].remove(filename)
+            for new_parent in new_parents.difference(old_parents):
+                self.children[new_parent].add(filename)
+            self.parents[filename] = new_parents

--- a/test_staticjinja.py
+++ b/test_staticjinja.py
@@ -4,7 +4,10 @@ except ImportError:
     import mock
 from pytest import fixture, raises
 
-from staticjinja import cli, make_site, Reloader
+from copy import deepcopy
+
+from staticjinja import cli, make_site, Reloader, DepGraph
+import staticjinja.staticjinja
 
 
 @fixture
@@ -24,12 +27,47 @@ def build_path(tmpdir):
 
 @fixture
 def site(template_path, build_path):
+    """
+    Provides a site with the following dependency structure
+    (all arrows pointing upward):
+    t1    t2
+      \  / |
+       p1  |  sub.t3
+      /| \ | /
+    d1 |  p2    t4
+       |    \  /
+      d2   data.d3
+    each t is a template, p is a partial and d is a data file.
+    There is also an ignored file .ignored1.html and a static files
+    in static_js/ static_css/ and favicon.ico
+    """
+
     template_path.join('.ignored1.html').write('Ignored 1')
-    template_path.join('_partial1.html').write('Partial 1')
-    template_path.join('template1.html').write('Test 1')
-    template_path.join('template2.html').write('Test 2')
-    template_path.mkdir('sub').join('template3.html').write('Test {{b}}')
-    template_path.join('template4.html').write('Test {{b}} and {{c}}')
+    template_path.join('_partial1.html').write(
+            'Partial 1\n'
+            '{% block content %}{% endblock -%}\n'
+            '{% import "_partial2.html" as p2 %}'
+            )
+    template_path.join('_partial2.html').write('Partial 2')
+    template_path.join('template1.html').write(
+            '{% extends "_partial1.html" %}\n'
+            '{% block content %}Template 1{% endblock -%}'
+            )
+    template_path.join('template2.html').write(
+            '{% extends "_partial1.html" %}\n'
+            '{% block content %}Test 2{% endblock -%}\n'
+            '{% include "_partial2.html" %}'
+            )
+    template_path.mkdir('sub').join('template3.html').write(
+            'Test {{b}}\n'
+            '{% include "_partial2.html" %}'
+            )
+    template_path.join('template4.html').write('Template {{b}} and {{c}}')
+
+    template_path.join('data1').write('Data 1')
+    template_path.join('data2').write('Data 2')
+    template_path.mkdir('data').join('data3').write('Data 3')
+
     template_path.mkdir('static_css').join('hello.css').write(
         'a { color: blue; }'
     )
@@ -37,6 +75,14 @@ def site(template_path, build_path):
         'var a = function () {return true};'
     )
     template_path.join('favicon.ico').write('Fake favicon')
+
+    staticpaths = ["static_css", "static_js", "favicon.ico"]
+    datapaths = ["data", "data/data3"]
+    extra_deps = {
+            '_partial1.html': ['data1', 'data2'],
+            '_partial2.html': ['data/data3'],
+            'template4.html': ['data/data3'],
+            }
     contexts = [('template2.html', lambda t: {'a': 1}),
                 ('.*template3.html', lambda: {'b': 3}),
                 ('template4.html', {'b': 4, 'c': 5}),
@@ -45,7 +91,97 @@ def site(template_path, build_path):
     return make_site(searchpath=str(template_path),
                      outpath=str(build_path),
                      contexts=contexts,
-                     rules=rules)
+                     rules=rules,
+                     staticpaths=staticpaths,
+                     datapaths=datapaths,
+                     extra_deps=extra_deps,
+                     )
+
+
+@fixture
+def expected_parents():
+    return {
+            'data2': set(),
+            'template4.html': set(['data/data3']),
+            'sub/template3.html': set(['_partial2.html']),
+            'template1.html': set(['_partial1.html']),
+            'data1': set(),
+            '_partial2.html': set(['data/data3']),
+            '_partial1.html': set(['data2', 'data1', '_partial2.html']),
+            'template2.html': set(['_partial1.html', '_partial2.html']),
+            'data/data3': set()
+            }
+
+
+@fixture
+def expected_children():
+    return {
+            'template1.html': set(),
+            'template2.html': set(),
+            'sub/template3.html': set(),
+            'template4.html': set(),
+            '_partial1.html': set(['template1.html', 'template2.html']),
+            '_partial2.html': set([
+                '_partial1.html',
+                'template2.html',
+                'sub/template3.html',
+                ]),
+            'data1': set(['_partial1.html']),
+            'data2': set(['_partial1.html']),
+            'data/data3': set(['_partial2.html', 'template4.html'])
+            }
+
+
+@fixture
+def expected_deps():
+    return {
+        '.ignored1': [],
+        'static_css/hello.css': ['static_css/hello.css'],
+        'static_js/hello.js': ['static_js/hello.js'],
+        'favicon.ico': ['favicon.ico'],
+        '_partial1.html': [
+                'template1.html',
+                'template2.html',
+                ],
+        '_partial2.html': [
+                '_partial1.html',
+                'sub/template3.html',
+                'template1.html',
+                'template2.html',
+                ],
+        'data1': [
+                '_partial1.html',
+                'template1.html',
+                'template2.html',
+                ],
+        'data2': [
+                '_partial1.html',
+                'template1.html',
+                'template2.html',
+                ],
+        'data/data3': [
+                '_partial1.html',
+                '_partial2.html',
+                'sub/template3.html',
+                'template1.html',
+                'template2.html',
+                'template4.html',
+                ],
+        'template1.html': ['template1.html'],
+        'template2.html': ['template2.html'],
+        'sub/template3.html': ['sub/template3.html'],
+        'template4.html': ['template4.html'],
+        }
+
+
+@fixture
+def mock_dep_graph_init(expected_parents, expected_children):
+    """Returns a mock constructor for DepGraph"""
+    def mock_init(self, site):
+        self.parents = expected_parents
+        self.children = expected_children
+        self.site = site
+    return mock_init
 
 
 @fixture
@@ -54,11 +190,11 @@ def reloader(site):
 
 
 def test_template_names(site):
-    site.staticpaths = ["static_css", "static_js", "favicon.ico"]
     expected_templates = set(['template1.html',
                               'template2.html',
                               'sub/template3.html',
-                              'template4.html'])
+                              'template4.html',
+                              ])
     assert set(site.template_names) == expected_templates
 
 
@@ -90,36 +226,172 @@ def test_get_rule(site):
     assert site.get_rule('template2.html')
 
 
-def test_get_dependencies(site, filename):
-    site.get_template = lambda x: filename
-    assert site.get_dependencies(".%s" % filename) == []
-    assert (list(site.get_dependencies("_%s" % filename)) ==
-            list(site.templates))
-    assert (list(site.get_dependencies("%s" % filename)) == [filename])
+def test_childrens(site, expected_children):
+    site.dep_graph = DepGraph(site)
+    assert site.dep_graph.children == expected_children
+
+
+def test_get_dependencies(
+        site,
+        mock_dep_graph_init,
+        expected_deps,
+        monkeypatch
+        ):
+    """Test site.get_dependencies. It actually mostly tests
+    DepGraph.connected_components but mocking the construction
+    of the dependency graph."""
+
+    monkeypatch.setattr(
+            staticjinja.DepGraph,
+            '__init__',
+            mock_dep_graph_init
+            )
+    site.dep_graph = DepGraph(site)
+    for filename in expected_deps:
+        deps = sorted(site.get_dependencies(filename))
+        assert deps == expected_deps[filename]
+
+
+def test_update_dependencies_remove_dep(
+        site,
+        mock_dep_graph_init, expected_children, expected_parents,
+        monkeypatch
+        ):
+    monkeypatch.setattr(
+            staticjinja.DepGraph,
+            '__init__',
+            mock_dep_graph_init
+            )
+    site.dep_graph = DepGraph(site)
+
+    # We will break the dependency of template2.html on _partial2.html
+    def update_file_dep(s, f):
+        if f == 'template2.html':
+            return set(['_partial1.html'])
+        else:
+            return expected_parents[f]
+
+    monkeypatch.setattr(
+            staticjinja.Site,
+            'get_file_dep',
+            update_file_dep
+            )
+
+    site.dep_graph.update('template2.html')
+
+    new_expected_parents = deepcopy(expected_parents)
+    new_expected_parents.update({'template2.html': set(['_partial1.html'])})
+    assert site.dep_graph.parents == new_expected_parents
+
+    new_expected_children = deepcopy(expected_children)
+    new_expected_children.update(
+            {'_partial2.html': set(['_partial1.html', 'sub/template3.html'])}
+            )
+    assert site.dep_graph.children == new_expected_children
+
+
+def test_update_dependencies_create_dep(
+        site,
+        mock_dep_graph_init, expected_children, expected_parents,
+        monkeypatch
+        ):
+    monkeypatch.setattr(
+            staticjinja.DepGraph,
+            '__init__',
+            mock_dep_graph_init
+            )
+    site.dep_graph = DepGraph(site)
+
+    # We create a dependency of template4.html on data1
+    def update_file_dep(s, f):
+        if f == 'template4.html':
+            return set(['data1', 'data/data3'])
+        else:
+            return expected_parents[f]
+
+    monkeypatch.setattr(
+            staticjinja.Site,
+            'get_file_dep',
+            update_file_dep
+            )
+
+    site.dep_graph.update('template4.html')
+
+    new_expected_parents = deepcopy(expected_parents)
+    new_expected_parents.update(
+            {'template4.html': set(['data1', 'data/data3'])}
+            )
+    assert site.dep_graph.parents == new_expected_parents
+
+    new_expected_children = deepcopy(expected_children)
+    new_expected_children.update(
+            {'data1': set(['_partial1.html', 'template4.html'])}
+            )
+    assert site.dep_graph.children == new_expected_children
+
+
+def test_update_dependencies_create_file(
+        site,
+        mock_dep_graph_init, expected_children, expected_parents,
+        monkeypatch
+        ):
+    monkeypatch.setattr(
+            staticjinja.DepGraph,
+            '__init__',
+            mock_dep_graph_init
+            )
+    site.dep_graph = DepGraph(site)
+
+    # We create a file template5.html depending on data1
+    def update_file_dep(s, f):
+        if f == 'template5.html':
+            return set(['data1'])
+        else:
+            return expected_parents[f]
+
+    monkeypatch.setattr(
+            staticjinja.Site,
+            'get_file_dep',
+            update_file_dep
+            )
+
+    site.dep_graph.update('template5.html')
+
+    new_expected_parents = deepcopy(expected_parents)
+    new_expected_parents.update(
+            {'template5.html': set(['data1'])}
+            )
+    assert site.dep_graph.parents == new_expected_parents
+
+    new_expected_children = deepcopy(expected_children)
+    new_expected_children.update(
+            {'data1': set(['_partial1.html', 'template5.html'])}
+            )
+    assert site.dep_graph.children == new_expected_children
 
 
 def test_render_template(site, build_path):
     site.render_template(site.get_template('template1.html'))
     template1 = build_path.join("template1.html")
     assert template1.check()
-    assert template1.read() == "Test 1"
+    assert template1.read() == "Partial 1\nTemplate 1"
 
 
 def test_render_nested_template(site, build_path):
     site.render_template(site.get_template('sub/template3.html'))
     template3 = build_path.join('sub').join("template3.html")
     assert template3.check()
-    assert template3.read() == "Test 3"
+    assert template3.read() == "Test 3\nPartial 2"
 
 
 def test_render_templates(site, build_path):
     site.render_templates(site.templates)
     template1 = build_path.join("template1.html")
     assert template1.check()
-    assert template1.read() == "Test 1"
+    assert template1.read() == "Partial 1\nTemplate 1"
     template3 = build_path.join('sub').join("template3.html")
     assert template3.check()
-    assert template3.read() == "Test 3"
+    assert template3.read() == "Test 3\nPartial 2"
 
 
 def test_build(site):
@@ -133,15 +405,11 @@ def test_build(site):
     assert templates == list(site.templates)
 
 
-def test_with_reloader(reloader, site):
-    reloader.watch_called = False
-
-    def watch(self):
-        reloader.watch_called = True
-
-    Reloader.watch = watch
+def test_use_reloader_calls_watch(reloader, site, monkeypatch):
+    mock_watch = mock.Mock()
+    monkeypatch.setattr(Reloader, 'watch', mock_watch)
     site.render(use_reloader=True)
-    assert reloader.watch_called
+    assert mock_watch.call_count == 1
 
 
 def test_should_handle(reloader, template_path):
@@ -155,16 +423,49 @@ def test_should_handle(reloader, template_path):
     assert not reloader.should_handle("deleted", str(template1_path))
 
 
-def test_event_handler(reloader, template_path):
-    templates = []
+def test_event_handler_ignored_files(reloader, template_path):
+    mock_render_templates = mock.Mock()
 
-    def fake_site(template, context=None, filepath=None):
-        templates.append(template)
+    reloader.site.render_templates = mock_render_templates
 
-    reloader.site.render_template = fake_site
+    ignored_path = str(template_path.join(".ignored.html"))
+    reloader.event_handler("modified", ignored_path)
+    reloader.event_handler("created", ignored_path)
+    reloader.event_handler("moved", ignored_path)
+    reloader.event_handler("deleted", ignored_path)
+    assert mock_render_templates.call_count == 0
+
+
+def test_event_handler_modify_template(reloader, template_path):
+    mock_render_templates = mock.Mock()
+
+    reloader.site.render_templates = mock_render_templates
+
     template1_path = str(template_path.join("template1.html"))
     reloader.event_handler("modified", template1_path)
-    assert templates == [reloader.site.get_template("template1.html")]
+    mock_render_templates.assert_called_once_with(["template1.html"])
+
+
+def test_event_handler_modify_partial(reloader, template_path):
+    mock_render_templates = mock.Mock()
+
+    reloader.site.render_templates = mock_render_templates
+
+    partial1_path = str(template_path.join("_partial1.html"))
+    reloader.event_handler("modified", partial1_path)
+    assert set(mock_render_templates.call_args[0][0]) == set(
+            ["template1.html", "template2.html"]
+            )
+
+
+def test_event_handler_create_template(reloader, template_path):
+    mock_render_templates = mock.Mock()
+    reloader.site.render_templates = mock_render_templates
+
+    template_path.join('template6.html').write('Template 6')
+    template6_path = str(template_path.join("template6.html"))
+    reloader.event_handler("created", template6_path)
+    mock_render_templates.assert_called_once_with(["template6.html"])
 
 
 def test_event_handler_static(reloader, template_path):


### PR DESCRIPTION
This is a first strike at issues #20 and #43 about smarter reloading and dependency management. It's not yet feature-complete but what is implemented should work and be enough to get the discussion rolling.  This is a somewhat sizable PR, the main code number of lines increases by one third while the test code number of lines doubles.

Remember the main issue is that, whenever a partial template changes, the reloader orders rendering of all templates, without checking which ones are impacted by the detected change (issue #20). A closely related problem is that data files used by context generators are ignored by the reloader (issue #43).

## User interface

This PR is fully backward compatible as far as the user interface is concerned. The twin main functions ``Site.__init__`` and ``make_site`` get two new arguments, both defaulting to ``None``: 
* ``datapaths``: a list of data files or data directory, mimicking the semantics of ``staticpaths``. Those files are not rendered by jinja nor copied in the build folder but, contrasting to ignored file, they will be monitored for changes.

* ``extra_deps``: a ``dict`` telling staticjinja about (maybe partial) templates depending on data files. Each key is a template and each value is a set of paths to a data file, relative to the source path.

That's all. The reloader will then try to be smart about which templates to render when a file changes or is created.

Nothing smart happens when a file is moved. The main reason is that easywatch is not ready to handle that (see Ceasar/easywatch#8). It would also add some complexity which we don't need in order to discuss the general scheme.

## Implementation

### The dependency graph

The main task is to create and maintain a dependency graph. The backbone is the method ``jinja2.meta.find_referenced_templates`` (see http://jinja.pocoo.org/docs/dev/api/#jinja2.meta.find_referenced_templates) whose documentation contains: 
> Finds all the referenced templates from the AST. This will return an iterator over all the hardcoded template extensions, inclusions and imports. If dynamic inheritance or inclusion is used, None will be yielded. [...] This function is useful for dependency tracking. For example if you want to rebuild parts of the website after a layout template has changed.

Of course Jinja2 cannot do anything about data files used by context generators, hence the ``extra_deps`` argument described above.  Alternatively we could ask each context generator to declare its dependencies, this would be equally easy to implement.

Those two sources give, for each (maybe partial) template or data file, a list of its immediate parents (here I'm using parent/child in the same direction Jinja2 uses it in http://jinja.pocoo.org/docs/dev/templates/#template-inheritance).  Have a look at fixtures ``site`` and ``expected_parents`` to make sure we're still on the same page.

But smart reloading is interested in the inverse relation: getting children (and grand-children and full descendancy) of a file. So we need to reverse this to get children, see fixture ``expected_children``.

From there we generate full descendancy using classical depth first search. See fixture ``expected_deps``. Note that I think we don't care about ordering the descendancy. In the end we will only render (non-partial) templates and those do not depend on each other so we can render them in any order. 

Of course a file change (or even worse creation) can necessitate updating the dependency graph. 

At first all this was distributed among modules ``staticjinja`` and ``reloader``. But then I changed my mind and created a ``dep_graph`` module containing a class ``DepGraph``. Of course instances of this class cannot forget about their parent ``Site`` which they need in order to call ``jinja2.meta.find_referenced_templates`` for updating purposes. This is very much similar to the situation of the ``Reloader`` class.

There is not much more to say about DepGraph except that its somewhat artificial split between methods ``get_descendants`` and ``connected_components`` is preparation for future work (see below).

### Changes in module ``staticjinja`` 

In the main module ``staticjinja`` there are trivial additions like a new set of files called ``jinja`` which gather partial templates and templates. They have their own property and test function. The same is of course true of data files. 

There are also small modifications caused by the fact that the current code sometimes carries around templates and sometimes paths to template.  I needed more consistency at some points. This impact methods ``render_templates`` and ``render`` (and probably also parts of the reloader).

Then of course the main difference is in the method ``get_dependencies`` which uses the dependency graph...

### Changes in module ``reloader``

Here of course we have a crucial change in the event handler but it's only about ten lines long since all the work is in the ``dep_graph`` module.

There is also a slight change for static files but only because I thought calling get_dependencies here was somewhat obscuring the situation. I also corrected an oversight about ignored files which probably used to be harmless but isn't anymore.

## Tests

The above changes are rather pervasive and depend on each other in a somewhat intricate way. I sort of know about the general idea that unit tests should be unit and isolated from each other using mocks. But actually doing it is way beyond my comfort zone. For one thing the size of the site fixture may mean I got too close to the realm of integration tests. Anyway, I spend much more time writing the tests than the main code but I wouldn't be surprised if they end up needing much more revision than the main code before merge.

## Documentation

I haven't changed anything to the documentation yet. But I will do it if it appears this will get merged.

## Performance

Invoking ``jinja2.meta.find_referenced_templates`` has a cost. All templates have to be parsed by Jinja2 and, as far as I can understand Jinja2 code, the result of this work is not cached for reuse when rendering. That's why ``Site.__init__`` does not create the dependency graph but only ``Reloader.__init__`` does it. We could also make this optional, even when using the reloader. Here my (debatable) reasoning is that it won't make any noticeable difference for small sites and larger ones will want smart reloading anyway.

One could ask whether building the graph from the output of ``jinja2.meta.find_referenced_templates`` could be a bottleneck. I haven't done any timing but I very much doubt there could be many sites with a deeply nester dependency graph so I guess we don't need powerful graph handling. Also, adding a project dependency on a general purpose graph theory library would feel like overkill to me, at least until someone complains my ``DepGraph`` is too slow.

## Future work

If we agree on (a variation on) the above then we can think about moving files and maybe events happening to directory. Especially moving files requires an improved ``easywatch`` module.

Next we have the dual feature of incremental build. With or without using the reloader, each call to render builds the whole site. We can open an issue about that but one should know (assuming this PR gets merged one way or the other) it would be very easy to implement. Indeed, the way we get information about the dependency graph is actually more directly relevant to incremental build where we want all ancestors of a given template rather than all descendants of a given data file or partial template. The ``DepGraph`` would only need the obvious ``get_ancestors`` method besides its ``get_descendants`` but the way ``get_ancestors`` is coded through ``connected_components`` paves the way for that extension. After that we only need a couple of ``os.path.getmtime`` to get going.

If this PR gets merged in any way, I'll probably open an issue about refactoring the test code, at least splitting it into several modules since it gets quite big. Also I think there are inconsistencies in the way things are done there but maybe it's not a problem.
