### PR TITLE
ensure there is a output dir regardless rules

### DIFF
--- a/staticjinja/staticjinja.py
+++ b/staticjinja/staticjinja.py
@@ -253,10 +253,12 @@ class Site(object):
 
         if context is None:
             context = self.get_context(template)
+
+        self._ensure_dir(template.name)
+
         try:
             rule = self.get_rule(template.name)
         except ValueError:
-            self._ensure_dir(template.name)
             if filepath is None:
                 filepath = os.path.join(self.outpath, template.name)
             template.stream(**context).dump(filepath, self.encoding)


### PR DESCRIPTION
Currently an output directory is only ensured when there isn't a rule.
